### PR TITLE
Add deb file for obs

### DIFF
--- a/CompileCommands.md
+++ b/CompileCommands.md
@@ -1,0 +1,21 @@
+# This files contains the commands required to compile the different applications stored in this repository.
+
+## OBS
+#### Installing Dependencies
+```
+sudo apt install build-essential checkinstall cmake git libmbedtls-dev libasound2-dev libavcodec-dev libavdevice-dev libavfilter-dev libavformat-dev libavutil-dev libcurl4-openssl-dev libfontconfig1-dev libfreetype6-dev libgl1-mesa-dev libjack-jackd2-dev libjansson-dev libluajit-5.1-dev libpulse-dev libqt5x11extras5-dev libspeexdsp-dev libswresample-dev libswscale-dev libudev-dev libv4l-dev libvlc-dev libx11-dev libx11-xcb1 libx11-xcb-dev libxcb-xinput0 libxcb-xinput-dev libxcb-randr0 libxcb-randr0-dev libxcb-xfixes0 libxcb-xfixes0-dev libx264-dev libxcb-shm0-dev libxcb-xinerama0-dev libxcomposite-dev libxinerama-dev pkg-config python3-dev qtbase5-dev libqt5svg5-dev swig libwayland-dev qtbase5-private-dev checkinstall
+wget http://ftp.debian.org/debian/pool/non-free/f/fdk-aac/libfdk-aac2_2.0.1-1_armhf.deb
+wget http://ftp.debian.org/debian/pool/non-free/f/fdk-aac/libfdk-aac-dev_2.0.1-1_armhf.deb
+sudo dpkg -i libfdk-aac2_2.0.1-1_armhf.deb
+sudo dpkg -i libfdk-aac-dev_2.0.1-1_armhf.deb
+```
+
+#### Compiling OBS from source
+```
+sudo git clone --recursive https://github.com/obsproject/obs-studio.git
+cd obs-studio
+sudo mkdir build
+cd build
+sudo cmake -DUNIX_STRUCTURE=1 -DCMAKE_INSTALL_PREFIX=/usr -DENABLE_PIPEWIRE=OFF -DBUILD_BROWSER=OFF ..
+sudo checkinstall --install=no
+```

--- a/CompileCommands.md
+++ b/CompileCommands.md
@@ -3,7 +3,7 @@
 ## OBS
 #### Installing Dependencies
 ```
-sudo apt install build-essential checkinstall cmake git libmbedtls-dev libasound2-dev libavcodec-dev libavdevice-dev libavfilter-dev libavformat-dev libavutil-dev libcurl4-openssl-dev libfontconfig1-dev libfreetype6-dev libgl1-mesa-dev libjack-jackd2-dev libjansson-dev libluajit-5.1-dev libpulse-dev libqt5x11extras5-dev libspeexdsp-dev libswresample-dev libswscale-dev libudev-dev libv4l-dev libvlc-dev libx11-dev libx11-xcb1 libx11-xcb-dev libxcb-xinput0 libxcb-xinput-dev libxcb-randr0 libxcb-randr0-dev libxcb-xfixes0 libxcb-xfixes0-dev libx264-dev libxcb-shm0-dev libxcb-xinerama0-dev libxcomposite-dev libxinerama-dev pkg-config python3-dev qtbase5-dev libqt5svg5-dev swig libwayland-dev qtbase5-private-dev checkinstall
+sudo apt install build-essential checkinstall cmake git libmbedtls-dev libasound2-dev libavcodec-dev libavdevice-dev libavfilter-dev libavformat-dev libavutil-dev libcurl4-openssl-dev libfontconfig1-dev libfreetype6-dev libgl1-mesa-dev libjack-jackd2-dev libjansson-dev libluajit-5.1-dev libpulse-dev libqt5x11extras5-dev libspeexdsp-dev libswresample-dev libswscale-dev libudev-dev libv4l-dev libvlc-dev libx11-dev libx11-xcb1 libx11-xcb-dev libxcb-xinput0 libxcb-xinput-dev libxcb-randr0 libxcb-randr0-dev libxcb-xfixes0 libxcb-xfixes0-dev libx264-dev libxcb-shm0-dev libxcb-xinerama0-dev libxcomposite-dev libxinerama-dev pkg-config python3-dev qtbase5-dev libqt5svg5-dev swig libwayland-dev qtbase5-private-dev 
 wget http://ftp.debian.org/debian/pool/non-free/f/fdk-aac/libfdk-aac2_2.0.1-1_armhf.deb
 wget http://ftp.debian.org/debian/pool/non-free/f/fdk-aac/libfdk-aac-dev_2.0.1-1_armhf.deb
 sudo dpkg -i libfdk-aac2_2.0.1-1_armhf.deb
@@ -12,9 +12,9 @@ sudo dpkg -i libfdk-aac-dev_2.0.1-1_armhf.deb
 
 #### Compiling OBS from source
 ```
-sudo git clone --recursive https://github.com/obsproject/obs-studio.git
+git clone --recursive https://github.com/obsproject/obs-studio.git
 cd obs-studio
-sudo mkdir build
+mkdir build
 cd build
 sudo cmake -DUNIX_STRUCTURE=1 -DCMAKE_INSTALL_PREFIX=/usr -DENABLE_PIPEWIRE=OFF -DBUILD_BROWSER=OFF ..
 sudo checkinstall --install=no


### PR DESCRIPTION
I just compiled the latest version of obs(v27) and thought it would be better if all the files used by pi apps be in one repository instead of a seperate repo owned by each person.  The is only the 32 bit deb and I have tested it on bullseye (did have to do some troubleshooting). Once this is merged i will update the pi-apps scripts with the new url and a fix for the seg fault happening in the latest version of obs. I am facing some problems getting it to work on 64 bit so that will take some more time.